### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: php
 php:
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,11 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.6"
+    "php": ">=5.6",
+    "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7 || ^6.5 || ^7.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/src/CsvValidatorParserTest.php
+++ b/tests/src/CsvValidatorParserTest.php
@@ -4,8 +4,9 @@ namespace Oshomo\CsvUtils\Validator;
 
 
 use Oshomo\CsvUtils\Tests\src\UppercaseRule;
+use PHPUnit\Framework\TestCase;
 
-class CsvValidatorParserTest extends \PHPUnit_Framework_TestCase
+class CsvValidatorParserTest extends TestCase
 {
     public function testWhenCustomRuleIsPassed()
     {

--- a/tests/src/CsvValidatorTest.php
+++ b/tests/src/CsvValidatorTest.php
@@ -6,8 +6,9 @@ namespace Oshomo\CsvUtils\Validator;
 use Oshomo\CsvUtils\Converter\JsonConverter;
 use Oshomo\CsvUtils\Converter\XmlConverter;
 use Oshomo\CsvUtils\Tests\src\UppercaseRule;
+use PHPUnit\Framework\TestCase;
 
-class CsvValidatorTest extends \PHPUnit_Framework_TestCase
+class CsvValidatorTest extends TestCase
 {
     /**
      * Test Assets Folder Path
@@ -270,6 +271,54 @@ class CsvValidatorTest extends \PHPUnit_Framework_TestCase
             $this->testAssets . "/valid_test_expected.xml",
             $this->testAssets . "/valid_test.xml"
         );
+    }
+
+    public function testValidatorCsvOnEmptyRule()
+    {
+        $file = $this->testAssets . "/valid_test.csv";
+
+        $expectedArray = [
+            'message' => 'CSV is valid.',
+            'data' => [
+                [
+                    'name' => 'Well Health Hotels',
+                    'address' => 'Inga N. P.O. Box 567',
+                    'stars' => '3',
+                    'contact' => 'Kasper Zen',
+                    'uri' => 'http://well.org'
+                ]
+            ]
+        ];
+
+        $validator = new Validator($file, ',', [
+            "stars" => ['']
+        ]);
+
+        $this->assertSame($expectedArray, $validator->validate());
+    }
+
+    public function testValidatorCsvIsValid()
+    {
+        $file = $this->testAssets . "/valid_test.csv";
+
+        $validator = new Validator($file, ',', [
+            "stars" => ["between:3,10"]
+        ]);
+
+        $expectedArray = [
+            'message' => 'CSV is valid.',
+            'data' => [
+                [
+                    'name' => 'Well Health Hotels',
+                    'address' => 'Inga N. P.O. Box 567',
+                    'stars' => '3',
+                    'contact' => 'Kasper Zen',
+                    'uri' => 'http://well.org'
+                ]
+            ]
+        ];
+
+        $this->assertSame($expectedArray, $validator->validate());
     }
 
     public function testValidatorXmlWriterWithRecordElementParameter()


### PR DESCRIPTION
# Changed log
- Add more tests.
- Add ```php-7.0```, ```php-7.1``` and ```php-7.2``` tests in Travis CI build and let ```php-nightly``` allow to be failed.
- Set the different PHPUnit version for different PHP versions.
- Use the class-based PHPUnit namespace to be compatible with the latest PHPUnit version.
- In code, it uses the ```mb_detect_encoding``` function so we should add the ```ext-mbstring``` to check whether the ```mbstring``` extnsion is installed when executing the ```composer install``` command.