### PR TITLE
Redundant implicit method

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,6 @@ use Oshomo\CsvUtils\Contracts\ValidationRuleInterface;
 
 class UppercaseRule implements ValidationRuleInterface
 {
-    /**
-     * Determine if the validation rule accepts parameters or not.
-     * If it does not accept any parameter return true else return false
-     *
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return true;
-    }
 
     /**
      * Get the number of parameters that should be supplied. 

--- a/src/Contracts/ValidationRuleInterface.php
+++ b/src/Contracts/ValidationRuleInterface.php
@@ -6,14 +6,6 @@ namespace Oshomo\CsvUtils\Contracts;
 interface ValidationRuleInterface
 {
     /**
-     * Determine if the validation rule accepts parameters or not.
-     * If it does not accept any parameter return true else return false
-     *
-     * @return boolean
-     */
-    public function isImplicit();
-
-    /**
      * Get the number of parameters that should be supplied.
      * If no parameter should be supplied return 0 else
      * return the number of parameters that should be returned

--- a/src/Rules/AsciiOnly.php
+++ b/src/Rules/AsciiOnly.php
@@ -9,16 +9,6 @@ class AsciiOnly implements ValidationRuleInterface
 {
 
     /**
-     * Determine if the validation rule accepts parameters or not.
-     *
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return true;
-    }
-
-    /**
      * Get the number of parameters that should be supplied
      *
      * @return integer

--- a/src/Rules/Between.php
+++ b/src/Rules/Between.php
@@ -10,16 +10,6 @@ class Between implements ValidationRuleInterface
     const PARAMETER_COUNT = 2;
 
     /**
-     * Determine if the validation rule accepts parameters or not.
-     *
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return false;
-    }
-
-    /**
      * Get the number of parameters that should be supplied
      *
      * @return integer

--- a/src/Rules/ClosureValidationRule.php
+++ b/src/Rules/ClosureValidationRule.php
@@ -40,16 +40,6 @@ class ClosureValidationRule implements ValidationRuleInterface
     }
 
     /**
-     * Determine if the validation rule accepts parameters or not.
-     *
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return true;
-    }
-
-    /**
      * Get the number of parameters that should be supplied
      *
      * @return integer

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -9,16 +9,6 @@ class Url implements ValidationRuleInterface
 {
 
     /**
-     * Determine if the validation rule accepts parameters or not.
-     *
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return true;
-    }
-
-    /**
      * Get the number of parameters that should be supplied
      *
      * @return integer

--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -378,13 +378,9 @@ class Validator
             $rule = $this->getRuleClass($rule);
         }
 
-        if ($rule->isImplicit()) {
-            return true;
-        } else {
-            $ruleParameterCount = $rule->parameterCount();
-            $parameterCount = count($parameters);
-            return ($ruleParameterCount === 0) ? true : ($parameterCount === $ruleParameterCount);
-        }
+        $ruleParameterCount = $rule->parameterCount();
+        $parameterCount = count($parameters);
+        return ($ruleParameterCount === 0) ? true : ($parameterCount === $ruleParameterCount);
 
     }
 

--- a/tests/src/UppercaseRule.php
+++ b/tests/src/UppercaseRule.php
@@ -7,13 +7,6 @@ use Oshomo\CsvUtils\Contracts\ValidationRuleInterface;
 
 class UppercaseRule implements ValidationRuleInterface
 {
-    /**
-     * @return boolean
-     */
-    public function isImplicit()
-    {
-        return true;
-    }
 
     /**
      * @return integer


### PR DESCRIPTION
Removed redundant `isImplicit()` method from validatorInterface. 