### PR TITLE
#5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ use Oshomo\CsvUtils\Validator\Validator;
 $validator = new Validator("some/valid/file_path", ",", [
     'title' => ["ascii_only", "url"]
 ], [
-    'ascii_only' => 'The :value supplied for :attribute attribute is invalid',
+    'ascii_only' => 'The :value supplied for :attribute attribute is invalid on line :line of the CSV.',
     // This specifies a custom message for a given attribute.
-    'hotel_link:url' => 'The :attribute must be a valid link',
+    'hotel_link:url' => 'The :attribute must be a valid link. This error occured on line :line of the CSV.',
 ]);
 ```
 
-In this above example, the `:attribute` place-holder will be replaced by the actual name of the field under validation. The `:value` place-holder will also be replaced with value being validated. You may also utilize other place-holders in validation messages. For example the `between` rule exposes two other placeholder `min` and `max`. Find more about this in the available rules section
+In this above example, the `:attribute` place-holder will be replaced by the actual name of the field under validation. The `:value` place-holder will be replaced with value being validated. The `:line` place-holder will also be replaced with the row/line number in the CSV in which the error happened. You may also utilize other place-holders in validation messages. For example the `between` rule exposes two other placeholder `min` and `max`. Find more about this in the available rules section
 
 ##### Available rules
 
@@ -206,7 +206,7 @@ class UppercaseRule implements ValidationRuleInterface
      */
     public function message()
     {
-        return "The :attribute value :value must be uppercase.";
+        return "The :attribute value :value must be uppercase on line :line.";
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ use Oshomo\CsvUtils\Validator\Validator;
 $file_path = realpath(dirname(__FILE__));
 $file = $file_path . '/sample/sample.csv';
 $validator = new Validator($file, ',', [
-    'stars' => ['between:0,5'],
+    'stars' => ['between:7,10'],
     'name' => ['ascii_only'],
     'uri' => ['url', function ($value, $fail) {
         if (0 !== strpos($value, 'https://')) {

--- a/src/Helpers/FormatsMessages.php
+++ b/src/Helpers/FormatsMessages.php
@@ -65,7 +65,7 @@ trait FormatsMessages
     /**
      * @param $rule
      *
-     * @return null|string|string[]
+     * @return string|string[]|null
      */
     protected function ruleToLower($rule)
     {
@@ -86,14 +86,17 @@ trait FormatsMessages
      * @param mixed                   $value
      * @param ValidationRuleInterface $rule
      * @param array                   $parameters
+     * @param $lineNumber
      *
      * @return string
      */
-    protected function makeReplacements($message, $attribute, $value, $rule, $parameters)
+    protected function makeReplacements($message, $attribute, $value, $rule, $parameters, $lineNumber)
     {
         $message = $this->replaceAttributePlaceholder($message, $attribute);
 
         $message = $this->replaceValuePlaceholder($message, $value);
+
+        $message = $this->replaceErrorLinePlaceholder($message, $lineNumber);
 
         $message = $rule->parameterReplacer($message, $parameters);
 
@@ -124,5 +127,18 @@ trait FormatsMessages
     protected function replaceValuePlaceholder($message, $value)
     {
         return str_replace([':value'], [$value], $message);
+    }
+
+    /**
+     * Replace the :line placeholder in the given message.
+     *
+     * @param $message
+     * @param $lineNUmber
+     *
+     * @return mixed
+     */
+    protected function replaceErrorLinePlaceholder($message, $lineNUmber)
+    {
+        return str_replace([':line'], [$lineNUmber], $message);
     }
 }

--- a/src/Rules/AsciiOnly.php
+++ b/src/Rules/AsciiOnly.php
@@ -36,7 +36,7 @@ class AsciiOnly implements ValidationRuleInterface
      */
     public function message()
     {
-        return 'The :attribute value :value contains a non-ascii character';
+        return 'The :attribute value :value contains a non-ascii character on line :line.';
     }
 
     /**

--- a/src/Rules/Between.php
+++ b/src/Rules/Between.php
@@ -40,7 +40,7 @@ class Between implements ValidationRuleInterface
      */
     public function message()
     {
-        return 'The :attribute value :value is not between :min - :max.';
+        return 'The :attribute value :value is not between :min - :max on line :line.';
     }
 
     /**

--- a/src/Rules/Url.php
+++ b/src/Rules/Url.php
@@ -57,7 +57,7 @@ class Url implements ValidationRuleInterface
      */
     public function message()
     {
-        return 'The :attribute value :value is not a valid url';
+        return 'The :attribute value :value is not a valid url on line :line.';
     }
 
     /**

--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -40,6 +40,13 @@ class Validator
     protected $message;
 
     /**
+     * The line number of the row under validation.
+     *
+     * @var int
+     */
+    protected $currentRowLineNumber = 0;
+
+    /**
      * The row under validation.
      *
      * @var array
@@ -79,7 +86,7 @@ class Validator
      *
      * @var string
      */
-    protected $delimiter;
+    protected $delimiter = ',';
 
     /**
      * The rules to be applied to the data.
@@ -110,7 +117,7 @@ class Validator
      * @param array  $rules
      * @param array  $messages
      */
-    public function __construct($filePath, $delimiter = ',', array $rules, array $messages = [])
+    public function __construct($filePath, $delimiter, array $rules, array $messages = [])
     {
         $this->filePath = $filePath;
         $this->delimiter = $delimiter;
@@ -175,6 +182,7 @@ class Validator
         if ($this->doesFileExistAndReadable($this->filePath)) {
             if (false !== ($handle = fopen($this->filePath, 'r'))) {
                 while (false !== ($row = fgetcsv($handle, 0, $this->delimiter))) {
+                    ++$this->currentRowLineNumber;
                     if (empty($this->headers)) {
                         $this->setHeaders($row);
                         continue;
@@ -269,7 +277,7 @@ class Validator
      * @param string $attribute
      * @param string $rule
      *
-     * @return null|void
+     * @return void|null
      */
     protected function validateAttribute($attribute, $rule)
     {
@@ -423,7 +431,8 @@ class Validator
             $attribute,
             $value,
             $rule,
-            $parameters
+            $parameters,
+            $this->currentRowLineNumber
         );
     }
 

--- a/tests/src/CsvValidatorTest.php
+++ b/tests/src/CsvValidatorTest.php
@@ -57,7 +57,7 @@ class CsvValidatorTest extends TestCase
         );
 
         $this->assertContains(
-            'The name value Well Health Hotels¡ contains a non-ascii character',
+            'The name value Well Health Hotels¡ contains a non-ascii character on line 2.',
             $validator->errors()['data'][0]['errors']
         );
     }
@@ -83,7 +83,7 @@ class CsvValidatorTest extends TestCase
         );
 
         $this->assertContains(
-            'The stars value 3 is not between 4 - 10.',
+            'The stars value 3 is not between 4 - 10 on line 2.',
             $validator->errors()['data'][0]['errors']
         );
     }
@@ -109,7 +109,7 @@ class CsvValidatorTest extends TestCase
         );
 
         $this->assertContains(
-            'The uri value http//:well.org is not a valid url',
+            'The uri value http//:well.org is not a valid url on line 2.',
             $validator->errors()['data'][0]['errors']
         );
     }
@@ -135,7 +135,7 @@ class CsvValidatorTest extends TestCase
         );
 
         $this->assertContains(
-            'The name value Well Health Hotels¡ must be uppercase.',
+            'The name value Well Health Hotels¡ must be uppercase on line 2.',
             $validator->errors()['data'][0]['errors']
         );
     }

--- a/tests/src/UppercaseRule.php
+++ b/tests/src/UppercaseRule.php
@@ -30,7 +30,7 @@ class UppercaseRule implements ValidationRuleInterface
      */
     public function message()
     {
-        return 'The :attribute value :value must be uppercase.';
+        return 'The :attribute value :value must be uppercase on line :line.';
     }
 
     /**


### PR DESCRIPTION
* Added :line placeholder replacer, to replace the row/line number which the error occurred in the CSV.
* Updated Validator to set row/line number and passed it to addFailure for setting the row/line number.
* Updated all supported rules to display line number in there error message.
* Updated test for checking if the line number is replaced properly.
* Updated the README so, developers know they can pass :line number as a placeholder when overwriting the Rules error message.