### PR TITLE
fix: add default value

### DIFF
--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -114,7 +114,7 @@ class Validator
     /**
      * Create a new Validator instance.
      */
-    public function __construct(string $filePath, string $delimiter = ',', array $rules, array $messages = [])
+    public function __construct(string $filePath, string $delimiter = ',', array $rules = [], array $messages = [])
     {
         $this->filePath = $filePath;
         $this->delimiter = $delimiter;


### PR DESCRIPTION
Add default value to rules argument in Validator::__construct to suppress php deprecation warning